### PR TITLE
fix: link in documentation was wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # KV9 - KAR meldpunten
 
-De documentatie is te vinden op de [BISON website](http://bison.dova.nu/standaarden/kv9).
+De documentatie is te vinden op de [BISON website](http://bison.dova.nu/standaarden/kv9-kar-meldpunten).
 
 Het XSD en evt. voorbeelden staan hier op github - zoek de juiste [release](http://github.com/BISONNL/KV9/releases)!


### PR DESCRIPTION
The url for the dova-website was incorrect, I fixed it